### PR TITLE
fix: calc.mod deprecated

### DIFF
--- a/plot.typ
+++ b/plot.typ
@@ -14,7 +14,7 @@
   if "stroke" in data and data.stroke != auto {
     return data.stroke
   }
-  return defaults.colors.at(calc.mod(n, defaults.colors.len()))
+  return defaults.colors.at(calc.rem(n, defaults.colors.len()))
 }
 
 /// Plot a line chart


### PR DESCRIPTION
Replace calc.mod with calc.rem
https://typst.app/docs/reference/calculate/mod/

fixes: calc.mod deprecated #4